### PR TITLE
Add breadcrumb component

### DIFF
--- a/src/components/breadcrumb/BreadcrumbBasic.vue
+++ b/src/components/breadcrumb/BreadcrumbBasic.vue
@@ -29,6 +29,6 @@ export default {
 <style scoped lang="scss">
 .el-breadcrumb {
 font-family: 'Lato', sans-serif;
-// font-size: 40px;
+font-size: 16px;
 }
 </style>

--- a/src/components/breadcrumb/BreadcrumbBasic.vue
+++ b/src/components/breadcrumb/BreadcrumbBasic.vue
@@ -1,0 +1,34 @@
+<template>
+    <el-breadcrumb :separator="separator">
+        <el-breadcrumb-item 
+            v-for="(item, index) in items" 
+            :key="index" 
+            :to="item.to"
+            :replace="item.replace">
+            {{item.label}}
+        </el-breadcrumb-item>
+    </el-breadcrumb>
+</template>
+
+<script>
+export default {
+  name: 'BreadcrumbBasic',
+  props: {
+    items: {
+      type: Array,
+      default: []
+    },
+    separator: {
+        type: String,
+        default: '/'
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.el-breadcrumb {
+font-family: 'Lato', sans-serif;
+// font-size: 40px;
+}
+</style>

--- a/src/components/breadcrumb/BreadcrumbIconSeparator.vue
+++ b/src/components/breadcrumb/BreadcrumbIconSeparator.vue
@@ -29,6 +29,6 @@ export default {
 <style scoped lang="scss">
 .el-breadcrumb {
 font-family: 'Lato', sans-serif;
-// font-size: 40px;
+font-size: 16px;
 }
 </style>

--- a/src/components/breadcrumb/BreadcrumbIconSeparator.vue
+++ b/src/components/breadcrumb/BreadcrumbIconSeparator.vue
@@ -1,0 +1,34 @@
+<template>
+    <el-breadcrumb :separator-class="separatorClass">
+        <el-breadcrumb-item 
+            v-for="(item, index) in items" 
+            :key="index" 
+            :to="item.to"
+            :replace="item.replace">
+            {{item.label}}
+        </el-breadcrumb-item>
+    </el-breadcrumb>
+</template>
+
+<script>
+export default {
+  name: 'BreadcrumbIconSeparator',
+  props: {
+    items: {
+      type: Array,
+      default: []
+    },
+    separatorClass: {
+        type: String,
+        default: 'el-icon-arrow-right'
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.el-breadcrumb {
+font-family: 'Lato', sans-serif;
+// font-size: 40px;
+}
+</style>

--- a/src/stories/Breadcrumb.stories.js
+++ b/src/stories/Breadcrumb.stories.js
@@ -1,0 +1,50 @@
+import BreadcrumbBasic from '../components/breadcrumb/BreadcrumbBasic.vue'
+import BreadcrumbIconSeparator from '../components/breadcrumb/BreadcrumbIconSeparator.vue'
+
+import { action } from '@storybook/addon-actions'
+
+// This is required for each story
+export default { title: 'Breadcrumb' }
+
+const items = [
+    {
+        to: {path: '/'},
+        label: 'Home'
+    },
+    {
+        to: {path: '/projects'},
+        label: 'projects'
+    },
+    {
+        label: 'Project 1'
+    }
+]
+
+// Customize components here. For instance, here's my-button component with a text of "with text"
+export const basicBreadCrumb = () => ({
+  components: { BreadcrumbBasic },
+  data() {
+    return {
+        items
+    }
+  },
+  template: `
+    <div>
+    <breadcrumb-basic :items="items" separator="|">Default</breadcrumb-basic>
+    </div>  
+  `
+})
+
+export const iconSeparatorBreadcrumb = () => ({
+    components: { BreadcrumbIconSeparator },
+    data() {
+      return {
+          items
+      }
+    },
+    template: `
+      <div>
+      <breadcrumb-icon-separator :items="items">Default</breadcrumb-icon-separator>
+      </div>  
+    `
+  })


### PR DESCRIPTION
## What is the Purpose?
This PR adds two basic implementations of the Breadcrumb, a simple one and then one which allows the use of an icon as a separator between items. 

## What was the approach?
Small adaptations from elements native components 

## Issue(s) affected?
#20 