### PR TITLE
Make components reusable

### DIFF
--- a/src/components/button/BasicButton.vue
+++ b/src/components/button/BasicButton.vue
@@ -23,4 +23,4 @@ export default {
 
 <style scoped>
 
-</style>>
+</style>

--- a/src/components/button/DisabledButton.vue
+++ b/src/components/button/DisabledButton.vue
@@ -22,4 +22,4 @@ export default {
 
 <style scoped>
 
-</style>>
+</style>

--- a/src/components/cascader/BasicCascader.vue
+++ b/src/components/cascader/BasicCascader.vue
@@ -1,8 +1,6 @@
 <template>
   <el-cascader
-    v-model="value"
     :options="options"
-    @change="handleChange"
   >
   </el-cascader>
 </template>
@@ -14,16 +12,6 @@ export default {
     options: {
       type: Array,
       default: []
-    }
-  },
-  methods: {
-    handleChange (value) {
-      console.log(value)
-    }
-  },
-  data () {
-    return {
-      value: []
     }
   }
 }

--- a/src/components/checkbox/BasicCheckbox.vue
+++ b/src/components/checkbox/BasicCheckbox.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-checkbox @click="$emit('click')" :type="type" v-model="checked">
+  <el-checkbox @click="$emit('click')" :type="type">
     <slot></slot>
   </el-checkbox>
 </template>
@@ -11,11 +11,6 @@ export default {
     type: {
       type: String,
       default: ''
-    }
-  },
-  data () {
-    return {
-      checked: true
     }
   }
 }

--- a/src/components/checkbox/BasicCheckbox.vue
+++ b/src/components/checkbox/BasicCheckbox.vue
@@ -1,18 +1,12 @@
 <template>
-  <el-checkbox @click="$emit('click')" :type="type">
+  <el-checkbox @click="$emit('click')">
     <slot></slot>
   </el-checkbox>
 </template>
 
 <script>
 export default {
-  name: 'BasicCheckbox',
-  props: {
-    type: {
-      type: String,
-      default: ''
-    }
-  }
+  name: 'BasicCheckbox'
 }
 </script>
 

--- a/src/components/checkbox/ButtonCheckbox.vue
+++ b/src/components/checkbox/ButtonCheckbox.vue
@@ -1,28 +1,33 @@
 <template>
-    <el-checkbox-group @click="$emit('click')" :size="size">
-      <el-checkbox-button>
-        <slot></slot>
-      </el-checkbox-button>
-    </el-checkbox-group>
+  <el-checkbox-group @click="$emit('click')" :size="size" v-model="checkboxGroup">
+    <el-checkbox-button v-for="item in dataArray" :label="item" :key="item">
+      {{item}}</el-checkbox-button>
+  </el-checkbox-group>
 </template>
 
 <script>
-
 export default {
   name: 'ButtonCheckbox',
   props: {
     size: {
       type: String,
       default: ''
+    },
+    dataArray: {
+      type: Array,
+      default: []
+    },
+    checkboxGroup: {
+      type: Array,
+      default: []
     }
   }
 }
 </script>
 
 <style>
-  .el-checkbox__label {
-    font-family: 'Lato',sans-serif;
-    font-weight: 300;
-  }
-
+.el-checkbox__label {
+  font-family: "Lato", sans-serif;
+  font-weight: 300;
+}
 </style>

--- a/src/components/checkbox/CheckboxGroup.vue
+++ b/src/components/checkbox/CheckboxGroup.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-checkbox-group @click="$emit('click')" :label="label" v-model="checkList">
+  <el-checkbox-group v-model="checkList">
     <slot></slot>
   </el-checkbox-group>
 </template>
@@ -8,10 +8,6 @@
 export default {
   name: 'CheckboxGroup',
   props: {
-    type: {
-      type: String,
-      default: ''
-    },
     checkList: {
       type: Array,
       default: []

--- a/src/components/checkbox/CheckboxGroup.vue
+++ b/src/components/checkbox/CheckboxGroup.vue
@@ -1,5 +1,5 @@
 <template>
-    <el-checkbox-group @click="$emit('click')" :type="type" v-model="checkList">
+  <el-checkbox-group @click="$emit('click')" :label="label" v-model="checkList">
     <slot></slot>
   </el-checkbox-group>
 </template>
@@ -11,16 +11,13 @@ export default {
     type: {
       type: String,
       default: ''
-    }
-  },
-  data () {
-    return {
-      checkList: ['Option A', 'Selected and disabled']
+    },
+    checkList: {
+      type: Array,
+      default: []
     }
   }
 }
 </script>
 
-<style>
-
-</style>
+<style></style>

--- a/src/components/checkbox/DisabledCheckbox.vue
+++ b/src/components/checkbox/DisabledCheckbox.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-checkbox @click="$emit('click')" :type="type" v-model="checked" disabled>
+  <el-checkbox @click="$emit('click')" :type="type" disabled>
     <slot></slot>
   </el-checkbox>
 </template>
@@ -11,11 +11,6 @@ export default {
     type: {
       type: String,
       default: ''
-    }
-  },
-  data () {
-    return {
-      checked: true
     }
   }
 }

--- a/src/components/input/BasicInput.vue
+++ b/src/components/input/BasicInput.vue
@@ -3,7 +3,7 @@
         <el-row :gutter="20">
             <el-col class="grid-content" :span="12">
                 <el-input
-                    placeholder="Input here"
+                    :placeholder="placeholder"
                     v-model="form.input">
                         <slot></slot>
                 </el-input>
@@ -19,9 +19,13 @@ export default {
     type: {
       type: String,
       default: ''
+    },
+    placeholder: {
+      type: String,
+      default: ''
     }
   },
-  data() {
+  data () {
     return {
       form: {
         input: ''

--- a/src/components/input/DisabledInput.vue
+++ b/src/components/input/DisabledInput.vue
@@ -3,7 +3,7 @@
         <el-row :gutter="20">
             <el-col class="grid-content" :span="12">
                 <el-input
-                    placeholder="Input here"
+                    :placeholder="placeholder"
                     v-model="form.input"
                     v-bind="$attrs"
                     v-on="$listeners">
@@ -19,6 +19,10 @@ export default {
   name: 'DisabledInput',
   props: {
     type: {
+      type: String,
+      default: ''
+    },
+    placeholder: {
       type: String,
       default: ''
     }

--- a/src/components/input/InputLength.vue
+++ b/src/components/input/InputLength.vue
@@ -6,7 +6,7 @@
                 <el-input
                     type="textarea"
                     :rows="4"
-                    placeholder="Text area input with limit"
+                    :placeholder="placeholder"
                     v-model="form.textarea"
                     v-bind="$attrs"
                     v-on="$listeners">
@@ -22,6 +22,10 @@ export default {
   name: 'TextArea',
   props: {
     type: {
+      type: String,
+      default: ''
+    },
+    placeholder: {
       type: String,
       default: ''
     }

--- a/src/components/input/PasswordBox.vue
+++ b/src/components/input/PasswordBox.vue
@@ -3,7 +3,7 @@
         <el-row :gutter="20">
             <el-col class="grid-content" :span="12">
                 <el-input
-                    placeholder="Enter password"
+                    :placeholder="placeholder"
                     v-model="form.input"
                     v-bind="$attrs"
                     v-on="$listeners">
@@ -19,6 +19,10 @@ export default {
   name: 'PasswordBox',
   props: {
     type: {
+      type: String,
+      default: ''
+    },
+    placeholder: {
       type: String,
       default: ''
     }

--- a/src/components/input/TextArea.vue
+++ b/src/components/input/TextArea.vue
@@ -5,7 +5,7 @@
                 <el-input
                     type="textarea"
                     :rows="4"
-                    placeholder="Text area input here"
+                    :placeholder="placeholder"
                     v-model="form.textarea">
                         <slot></slot>
                 </el-input>
@@ -19,6 +19,10 @@ export default {
   name: 'TextArea',
   props: {
     type: {
+      type: String,
+      default: ''
+    },
+    placeholder: {
       type: String,
       default: ''
     }

--- a/src/components/navMenu/CollapseNav.vue
+++ b/src/components/navMenu/CollapseNav.vue
@@ -3,8 +3,6 @@
     <el-menu
       :default-active="defaultActive"
       class="el-menu-vertical-demo"
-      @open="handleOpen"
-      @close="handleClose"
       :collapse="isCollapse"
     >
       <slot></slot>
@@ -33,14 +31,6 @@ export default {
   data () {
     return {
       isCollapse: true
-    }
-  },
-  methods: {
-    handleOpen (key, keyPath) {
-      console.log(key, keyPath)
-    },
-    handleClose (key, keyPath) {
-      console.log(key, keyPath)
     }
   }
 }

--- a/src/components/navMenu/TopNav.vue
+++ b/src/components/navMenu/TopNav.vue
@@ -3,7 +3,6 @@
     :default-active="activeIndex"
     class="el-menu-demo"
     mode="horizontal"
-    @select="handleSelect"
     :index="index"
   >
   <slot></slot>
@@ -21,11 +20,6 @@ export default {
     activeIndex: {
       type: String,
       default: ''
-    }
-  },
-  methods: {
-    handleSelect (key, keyPath) {
-      console.log(key, keyPath)
     }
   }
 }

--- a/src/components/switch/BasicSwitch.vue
+++ b/src/components/switch/BasicSwitch.vue
@@ -1,5 +1,6 @@
 <template>
-    <el-switch v-model="value1"
+    <el-switch
+    v-model="value"
     :active-color="activeColor"
     :inactive-color="inactiveColor"
     @click="$emit('click')">
@@ -17,11 +18,10 @@ export default {
     inactiveColor: {
       type: String,
       default: ''
-    }
-  },
-  data () {
-    return {
-      value1: true
+    },
+    value: {
+      type: Boolean,
+      default: true
     }
   }
 }

--- a/src/components/switch/DisabledSwitch.vue
+++ b/src/components/switch/DisabledSwitch.vue
@@ -1,5 +1,5 @@
 <template>
-    <el-switch v-model="value1"
+    <el-switch v-model="value"
     :active-color="activeColor"
     :inactive-color="inactiveColor"
     @click="$emit('click')"
@@ -18,11 +18,10 @@ export default {
     inactiveColor: {
       type: String,
       default: ''
-    }
-  },
-  data () {
-    return {
-      value1: true
+    },
+    value: {
+      type: Boolean,
+      default: true
     }
   }
 }

--- a/src/components/switch/TextSwitch.vue
+++ b/src/components/switch/TextSwitch.vue
@@ -1,5 +1,5 @@
 <template>
-    <el-switch v-model="value1"
+    <el-switch v-model="value"
     :active-color="activeColor"
     :inactive-color="inactiveColor"
     :active-text="activeText"
@@ -27,11 +27,10 @@ export default {
     inactiveText: {
       type: String,
       default: ''
-    }
-  },
-  data () {
-    return {
-      value1: true
+    },
+    value: {
+      type: Boolean,
+      default: true
     }
   }
 }

--- a/src/stories/Checkbox.stories.js
+++ b/src/stories/Checkbox.stories.js
@@ -33,12 +33,12 @@ export const checkboxGroup = () => ({
   components: { CheckboxGroup },
   data () {
     return {
-      checkList: ['selected and disabled', 'Option A']
+      checkList: ['Selected and disabled', 'Option A']
     }
   },
   template: `
     <div>
-    <checkbox-group @click="action" v-model="checkList">
+    <checkbox-group v-model="checkList">
     <el-checkbox label="Option A"></el-checkbox>
     <el-checkbox label="Option B"></el-checkbox>
     <el-checkbox label="Option C"></el-checkbox>
@@ -46,8 +46,7 @@ export const checkboxGroup = () => ({
     <el-checkbox label="Selected and disabled" disabled></el-checkbox>
     </checkbox-group>
     </div>  
-    `,
-  methods: { action: action('click') }
+    `
 })
 
 export const buttonCheckbox = () => ({

--- a/src/stories/Checkbox.stories.js
+++ b/src/stories/Checkbox.stories.js
@@ -31,9 +31,14 @@ export const disabledCheckbox = () => ({
 
 export const checkboxGroup = () => ({
   components: { CheckboxGroup },
+  data () {
+    return {
+      checkList: ['selected and disabled', 'Option A']
+    }
+  },
   template: `
     <div>
-    <checkbox-group @click="action">
+    <checkbox-group @click="action" v-model="checkList">
     <el-checkbox label="Option A"></el-checkbox>
     <el-checkbox label="Option B"></el-checkbox>
     <el-checkbox label="Option C"></el-checkbox>
@@ -47,14 +52,15 @@ export const checkboxGroup = () => ({
 
 export const buttonCheckbox = () => ({
   components: { ButtonCheckbox },
+  data () {
+    return {
+      dataArray: ['Option A', 'Option B', 'Option C', 'Option D']
+    }
+  },
   template: `
       <div>
-      <checkbox-group @click="action" size="medium">
-        <el-checkbox-button>Option A</el-checkbox-button>
-        <el-checkbox-button>Option B</el-checkbox-button>
-        <el-checkbox-button>Option C</el-checkbox-button>
-        <el-checkbox-button>Option D</el-checkbox-button>
-      </checkbox-group>
+      <button-checkbox @click="action" size="medium" :dataArray='dataArray'>
+      </button-checkbox>
       </div>
       `,
   methods: { action: action('click') }

--- a/src/stories/Input.stories.js
+++ b/src/stories/Input.stories.js
@@ -13,7 +13,7 @@ export const basicInput = () => ({
     components: { BasicInput },
     template: `
     <div>
-      <basic-input type="text"></basic-input>
+      <basic-input placeholder="Input here"></basic-input>
     </div>
   `
   })
@@ -22,7 +22,7 @@ export const disabledInput = () => ({
     components: { DisabledInput },
     template: `
     <div>
-      <disabled-input type="text" disabled></disabled-input>
+      <disabled-input placeholder="Input here" disabled></disabled-input>
     </div>
   `
   })
@@ -31,7 +31,7 @@ export const disabledInput = () => ({
     components: { ClearInput },
     template: `
     <div>
-      <clear-input type="text" clearable></clear-input>
+      <clear-input clearable></clear-input>
     </div>
   `
   })
@@ -40,7 +40,7 @@ export const disabledInput = () => ({
     components: { PasswordBox },
     template: `
     <div>
-      <password-box type="text" show-password></password-box>
+      <password-box placeholder="Enter password" show-password></password-box>
     </div>
   `
   })
@@ -49,7 +49,7 @@ export const disabledInput = () => ({
     components: { TextArea },
     template: `
     <div>
-      <text-area type="textarea"></text-area>
+      <text-area placeholder="Text area input here"></text-area>
     </div>
   `
   })
@@ -58,7 +58,7 @@ export const disabledInput = () => ({
     components: { InputLength },
     template: `
     <div>
-    <input-length type="textarea" maxlength="100" show-word-limit></input-length>
+    <input-length maxlength="100" placeholder="Text area input with limit" show-word-limit></input-length>
     </div>
   `
   })

--- a/src/stories/Switch.stories.js
+++ b/src/stories/Switch.stories.js
@@ -10,9 +10,15 @@ export default { title: 'Switch' }
 // Customize components here. For instance, here's my-button component with a text of "with text"
 export const basicSwitch = () => ({
   components: { BasicSwitch },
+  data () {
+    return {
+      value: true
+    }
+  },
   template: `
     <div>
       <basic-switch
+          v-model="value"
           activeColor="#25CED1"
           inactiveColor="#E1E1E1"
           @click="action">
@@ -24,9 +30,15 @@ export const basicSwitch = () => ({
 
 export const textSwitch = () => ({
   components: { TextSwitch },
+  data () {
+    return {
+      value: true
+    }
+  },
   template: `
       <div>
         <text-switch
+            v-model="value"
             activeColor="#25CED1"
             inactiveColor="#E1E1E1"
             activeText="Activate user"
@@ -40,9 +52,15 @@ export const textSwitch = () => ({
 
 export const disabledSwitch = () => ({
   components: { DisabledSwitch },
+  data () {
+    return {
+      value: true
+    }
+  },
   template: `
       <div>
         <disabled-switch
+            v-model="value"
             activeColor="#25CED1"
             inactiveColor="#E1E1E1"
             @click="action">


### PR DESCRIPTION
## What is the Purpose?
- Cascader: remove unused `methods` and `data`
- Checkbox: remove unused `data` and props, expose data array
- Input: add `placeholder` as props
- Navbar: remove unused `methods`
- Switch: add v-model value as props

## What was the approach?
Add props and remove unused methods

## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@andrewtpham @hvitis 

## Issue(s) affected?
None
